### PR TITLE
NPE fix for Donut PiePlot in pointRenderers

### DIFF
--- a/gral-core/src/main/java/de/erichseifert/gral/plots/PiePlot.java
+++ b/gral-core/src/main/java/de/erichseifert/gral/plots/PiePlot.java
@@ -915,9 +915,11 @@ public class PiePlot extends AbstractPlot implements Navigable {
 			throw new IllegalArgumentException(
 				"This plot type only supports a single data source."); //$NON-NLS-1$
 		}
-		super.add(index, source, visible);
+
 		PointRenderer pointRendererDefault = new PieSliceRenderer(this);
 		setPointRenderer(source, pointRendererDefault);
+
+		super.add(index, source, visible);
 		setMapping(source, AXIS_TANGENTIAL);
 	}
 


### PR DESCRIPTION
**What happened?**

In examples Donut plot does not open

**What is the reason?**

NPE:
```
Exception in thread "AWT-EventQueue-0" java.lang.NullPointerException
	at de.erichseifert.gral.plots.PiePlot$LegendSymbol.draw(PiePlot.java:828)
	at de.erichseifert.gral.graphics.DrawableContainer.drawComponents(DrawableContainer.java:95)
	at de.erichseifert.gral.graphics.DrawableContainer.draw(DrawableContainer.java:86)
	at de.erichseifert.gral.graphics.DrawableContainer.drawComponents(DrawableContainer.java:95)
	at de.erichseifert.gral.plots.legends.AbstractLegend.draw(AbstractLegend.java:204)
	at de.erichseifert.gral.plots.AbstractPlot.drawLegend(AbstractPlot.java:214)
	at de.erichseifert.gral.plots.PiePlot$PiePlotArea2D.draw(PiePlot.java:251)
	at de.erichseifert.gral.graphics.DrawableContainer.drawComponents(DrawableContainer.java:95)
	at de.erichseifert.gral.plots.AbstractPlot.draw(AbstractPlot.java:191)
	at de.erichseifert.gral.ui.DrawablePanel.paintComponent(DrawablePanel.java:79)
	at javax.swing.JComponent.paint(JComponent.java:1056)
	at javax.swing.JComponent.paintChildren(JComponent.java:889)
	at javax.swing.JComponent.paint(JComponent.java:1065)
	at javax.swing.JComponent.paintChildren(JComponent.java:889)
	at javax.swing.JComponent.paint(JComponent.java:1065)
	at javax.swing.JViewport.paint(JViewport.java:728)
	at javax.swing.JComponent.paintChildren(JComponent.java:889)
	at javax.swing.JComponent.paint(JComponent.java:1065)
	at javax.swing.JComponent.paintToOffscreen(JComponent.java:5210)
	at javax.swing.BufferStrategyPaintManager.paint(BufferStrategyPaintManager.java:290)
	at javax.swing.RepaintManager.paint(RepaintManager.java:1272)
	at javax.swing.JComponent._paintImmediately(JComponent.java:5158)
	at javax.swing.JComponent.paintImmediately(JComponent.java:4969)
	at javax.swing.RepaintManager$4.run(RepaintManager.java:831)
	at javax.swing.RepaintManager$4.run(RepaintManager.java:814)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:80)
	at javax.swing.RepaintManager.paintDirtyRegions(RepaintManager.java:814)
	at javax.swing.RepaintManager.paintDirtyRegions(RepaintManager.java:789)
	at javax.swing.RepaintManager.prePaintDirtyRegions(RepaintManager.java:738)
	at javax.swing.RepaintManager.access$1200(RepaintManager.java:64)
	at javax.swing.RepaintManager$ProcessingRunnable.run(RepaintManager.java:1732)
	at java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:311)
	at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:756)
	at java.awt.EventQueue.access$500(EventQueue.java:97)
	at java.awt.EventQueue$3.run(EventQueue.java:709)
	at java.awt.EventQueue$3.run(EventQueue.java:703)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:80)
	at java.awt.EventQueue.dispatchEvent(EventQueue.java:726)
	at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:201)
	at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:116)
	at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:105)
	at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
	at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:93)
	at java.awt.EventDispatchThread.run(EventDispatchThread.java:82)
```

