### PR TITLE
Fixing #70 "DataSource should have a "name" Property" 

### DIFF
--- a/gral-core/src/main/java/de/erichseifert/gral/plots/legends/SeriesLegend.java
+++ b/gral-core/src/main/java/de/erichseifert/gral/plots/legends/SeriesLegend.java
@@ -67,7 +67,7 @@ public abstract class SeriesLegend extends AbstractLegend {
 	 * @return Label text.
 	 */
 	protected String getLabel(DataSource data) {
-		return data.toString();
+		return data.getName();
 	}
 
 	/**


### PR DESCRIPTION
Issue #70 criticized that legends display class name and object id instead of a
name that is relevant to the user. That issue had been closed prematurely. Instead of reposting the same issue, I decided to provide a patch.
This patch replaces DataSource.toString() with DataSoure.getName() in SeriesLegend.getLabel().